### PR TITLE
Refactor resize event to use ResizeEventArgs object

### DIFF
--- a/API.md
+++ b/API.md
@@ -116,8 +116,8 @@ Events:
 
 | Event | Handler type | Browser event |
 | --- | --- | --- |
-| `OnResize` | `Action<double, double>` | `window.onresize` |
-| `OnResizeAsync` | `Func<double, double, Task>` | `window.onresize` |
+| `OnResize` | `Action<ResizeEventArgs>` | `window.onresize` |
+| `OnResizeAsync` | `Func<ResizeEventArgs, Task>` | `window.onresize` |
 | `OnScroll` | `Action<EventArgs>` | `window.onscroll` |
 | `OnScrollAsync` | `Func<EventArgs, Task>` | `window.onscroll` |
 | `OnMouseOver` | `Action<MouseEventArgs>` | `window.onmouseover` |
@@ -160,9 +160,9 @@ Events:
 Example:
 
 ```csharp
-Bq.Events.OnResize += (width, height) =>
+Bq.Events.OnResize += e =>
 {
-    Console.WriteLine($"Viewport: {width} x {height}");
+    Console.WriteLine($"Viewport: {e.Width} x {e.Height}");
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ note: all the method not show the first patameter:  *this ElementReference eleme
 
 | name                         | describe                     | parameters        |
 | ---------------------------- | ---------------------------- | ----------------- |
-| `event Action OnResize`      | window.onresize event.       | 1: width 2:height |
-| `event Func OnResizeAsync`   | async window.onresize event. | 1: width 2:height |
+| `event Action<ResizeEventArgs> OnResize`      | window.onresize event.       | ResizeEventArgs |
+| `event Func<ResizeEventArgs, Task> OnResizeAsync`   | async window.onresize event. | ResizeEventArgs |
 | `event Action OnScroll`      | window.onscroll event        | EventArgs         |
 | `event Action OnScrollasync` | async window.onscroll event  | EventArgs         |
 | `event Action<MouseEventArgs> OnMouseOver` | window.onmouseover event | MouseEventArgs |

--- a/Sample/BQuery.Sample.Common/Pages/Index.razor
+++ b/Sample/BQuery.Sample.Common/Pages/Index.razor
@@ -129,10 +129,10 @@
         await base.OnAfterRenderAsync(firstRender);
     }
 
-    private async Task OnWindowResizeAsync(double width, double height)
+    private async Task OnWindowResizeAsync(ResizeEventArgs e)
     {
-        vw = width;
-        vh = height;
+        vw = e.Width;
+        vh = e.Height;
 
         var scrollWH = await Bq.Viewport.GetScrollWidthAndHeightAsync();
         scrollW = scrollWH[0];

--- a/src/BqEvents.cs
+++ b/src/BqEvents.cs
@@ -43,22 +43,20 @@ namespace BQuery
 
         /// <summary>
         /// window.onresize event
-        /// first parameter is width,
-        /// second first parameter is height
+        /// resize args include width and height.
         /// </summary>
-        public event Action<double, double> OnResize;
+        public event Action<ResizeEventArgs> OnResize;
         
         /// <summary>
         /// async window.onresize event
-        /// first parameter is width,
-        /// second first parameter is height, 
+        /// resize args include width and height.
         /// </summary>
-        public event Func<double, double, Task> OnResizeAsync;
+        public event Func<ResizeEventArgs, Task> OnResizeAsync;
 
-        internal void InvokeOnResize(double width, double height)
+        internal void InvokeOnResize(ResizeEventArgs e)
         {
-            OnResize?.Invoke(width, height);
-            OnResizeAsync?.Invoke(width, height);
+            OnResize?.Invoke(e);
+            OnResizeAsync?.Invoke(e);
         }
         
         #endregion

--- a/src/BqInterop.cs
+++ b/src/BqInterop.cs
@@ -90,12 +90,11 @@ namespace BQuery
         /// <summary>
         /// js callback on window.onresize trigger
         /// </summary>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
+        /// <param name="e"></param>
         [JSInvokable]
-        public static void WindowResize(double width, double height)
+        public static void WindowResize(ResizeEventArgs e)
         {
-            Bq.Events.InvokeOnResize(width, height);
+            Bq.Events.InvokeOnResize(e);
         }
 
         /// <summary>

--- a/src/ResizeEventArgs.cs
+++ b/src/ResizeEventArgs.cs
@@ -1,0 +1,12 @@
+namespace BQuery
+{
+    /// <summary>
+    /// Window resize event args.
+    /// </summary>
+    public class ResizeEventArgs
+    {
+        public double Width { get; set; }
+
+        public double Height { get; set; }
+    }
+}

--- a/src/wwwroot/src/module/eventHelper.ts
+++ b/src/wwwroot/src/module/eventHelper.ts
@@ -143,7 +143,7 @@ const bindEvent = () => {
 
     window.onresize = throttle(() => {
         var vwhArr = Viewport.getWidthAndHeight();
-        DotNet.invokeMethodAsync("BQuery", "WindowResize", vwhArr[0], vwhArr[1]);
+        DotNet.invokeMethodAsync("BQuery", "WindowResize", { width: vwhArr[0], height: vwhArr[1] });
     }, defaultThrottleTicks);
 
     window.onscroll = throttle((e: Event) => {


### PR DESCRIPTION
### Motivation
- Package the two `double` resize parameters into a single `ResizeEventArgs` object to make the API cleaner and more extensible.
- Update the JS interop surface so the browser sends a single object payload for resize events, enabling a single-parameter event signature in C#.

### Description
- Added `ResizeEventArgs` with `double Width` and `double Height` in `src/ResizeEventArgs.cs` and updated `BqEvents` to expose `OnResize` and `OnResizeAsync` as `Action<ResizeEventArgs>` and `Func<ResizeEventArgs, Task>` respectively, and changed `InvokeOnResize` to accept `ResizeEventArgs` instead of two `double`s.  
- Changed the JS interop bridge `WindowResize` to accept `ResizeEventArgs` and forward it to `Bq.Events.InvokeOnResize(e)` in `src/BqInterop.cs`.  
- Updated front-end callback to send an object payload: in `src/wwwroot/src/module/eventHelper.ts` the call is now `DotNet.invokeMethodAsync("BQuery", "WindowResize", { width: vwhArr[0], height: vwhArr[1] });`.  
- Updated the sample handler signature in `Sample/BQuery.Sample.Common/Pages/Index.razor` to `OnWindowResizeAsync(ResizeEventArgs e)` and updated `API.md` and `README.md` to reflect the new signatures and example usage.  
- Searched for `EventSlot<T1, T2>` / `EventSlot` and found no occurrences in the repository, so nothing was removed for that type.

### Testing
- Ran `npm --prefix src/wwwroot install` which completed successfully.  
- Ran `npm --prefix src/wwwroot run build` which completed successfully and produced `dist/bQuery.min.js`.  
- Attempted `dotnet build src/BQuery.csproj` but it could not be executed in this environment because `dotnet` is not available.  
- Verified code edits and repository references with `rg`/searches to ensure all resize callsites and docs were updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a70772c5b8832180474d0e96a809c3)