### PR TITLE
Generate WindowEvent-to-EventSlot dictionary in window events generator

### DIFF
--- a/src/BQuery.SourceGenerators/WindowEventsGenerator.cs
+++ b/src/BQuery.SourceGenerators/WindowEventsGenerator.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -145,11 +144,15 @@ public sealed class WindowEventsGenerator : IIncrementalGenerator
         builder.Append("public partial class ").Append(target.ClassSymbol.Name).AppendLine();
         builder.AppendLine("{");
 
-        foreach (var windowEvent in target.Events)
+        builder.AppendLine("    private readonly Dictionary<WindowEvent, EventSlot> _eventSlots = new()");
+        builder.AppendLine("    {");
+
+        for (var i = 0; i < target.Events.Count; i++)
         {
-            AppendField(builder, windowEvent, typeFormat);
+            AppendField(builder, target.Events[i], typeFormat, i == target.Events.Count - 1);
         }
 
+        builder.AppendLine("    };");
         builder.AppendLine();
 
         foreach (var windowEvent in target.Events)
@@ -161,9 +164,11 @@ public sealed class WindowEventsGenerator : IIncrementalGenerator
         return builder.ToString();
     }
 
-    private static void AppendField(StringBuilder builder, WindowEventInfo windowEvent, SymbolDisplayFormat typeFormat)
+    private static void AppendField(StringBuilder builder, WindowEventInfo windowEvent, SymbolDisplayFormat typeFormat, bool isLast)
     {
-        builder.Append("    private readonly EventSlot<")
+        builder.Append("        [WindowEvent.")
+            .Append(windowEvent.MemberName)
+            .Append("] = new EventSlot<")
             .Append(windowEvent.ArgumentType1.ToDisplayString(typeFormat));
 
         if (windowEvent.ArgumentType2 is not null)
@@ -172,9 +177,14 @@ public sealed class WindowEventsGenerator : IIncrementalGenerator
                 .Append(windowEvent.ArgumentType2.ToDisplayString(typeFormat));
         }
 
-        builder.Append("> ")
-            .Append(windowEvent.SlotName)
-            .AppendLine(" = new();");
+        builder.Append(">()");
+
+        if (!isLast)
+        {
+            builder.Append(",");
+        }
+
+        builder.AppendLine();
     }
 
     private static void AppendMembers(StringBuilder builder, WindowEventInfo windowEvent, SymbolDisplayFormat typeFormat)
@@ -193,8 +203,31 @@ public sealed class WindowEventsGenerator : IIncrementalGenerator
             .AppendLine("    /// </summary>");
         builder.Append("    public event ").Append(eventType).Append("? ").Append(windowEvent.MemberName).AppendLine();
         builder.AppendLine("    {");
-        builder.Append("        add => ").Append(windowEvent.SlotName).AppendLine(".Sync += value;");
-        builder.Append("        remove => ").Append(windowEvent.SlotName).AppendLine(".Sync -= value;");
+        builder.Append("        add => ((EventSlot<")
+            .Append(windowEvent.ArgumentType1.ToDisplayString(typeFormat));
+
+        if (windowEvent.ArgumentType2 is not null)
+        {
+            builder.Append(", ")
+                .Append(windowEvent.ArgumentType2.ToDisplayString(typeFormat));
+        }
+
+        builder.Append(">)_eventSlots[WindowEvent.")
+            .Append(windowEvent.MemberName)
+            .AppendLine("]).Sync += value;");
+
+        builder.Append("        remove => ((EventSlot<")
+            .Append(windowEvent.ArgumentType1.ToDisplayString(typeFormat));
+
+        if (windowEvent.ArgumentType2 is not null)
+        {
+            builder.Append(", ")
+                .Append(windowEvent.ArgumentType2.ToDisplayString(typeFormat));
+        }
+
+        builder.Append(">)_eventSlots[WindowEvent.")
+            .Append(windowEvent.MemberName)
+            .AppendLine("]).Sync -= value;");
         builder.AppendLine("    }");
         builder.AppendLine();
         builder.Append("    /// <summary>").AppendLine();
@@ -204,8 +237,31 @@ public sealed class WindowEventsGenerator : IIncrementalGenerator
             .AppendLine("    /// </summary>");
         builder.Append("    public event ").Append(asyncEventType).Append("? ").Append(windowEvent.MemberName).AppendLine("Async");
         builder.AppendLine("    {");
-        builder.Append("        add => ").Append(windowEvent.SlotName).AppendLine(".Async += value;");
-        builder.Append("        remove => ").Append(windowEvent.SlotName).AppendLine(".Async -= value;");
+        builder.Append("        add => ((EventSlot<")
+            .Append(windowEvent.ArgumentType1.ToDisplayString(typeFormat));
+
+        if (windowEvent.ArgumentType2 is not null)
+        {
+            builder.Append(", ")
+                .Append(windowEvent.ArgumentType2.ToDisplayString(typeFormat));
+        }
+
+        builder.Append(">)_eventSlots[WindowEvent.")
+            .Append(windowEvent.MemberName)
+            .AppendLine("]).Async += value;");
+
+        builder.Append("        remove => ((EventSlot<")
+            .Append(windowEvent.ArgumentType1.ToDisplayString(typeFormat));
+
+        if (windowEvent.ArgumentType2 is not null)
+        {
+            builder.Append(", ")
+                .Append(windowEvent.ArgumentType2.ToDisplayString(typeFormat));
+        }
+
+        builder.Append(">)_eventSlots[WindowEvent.")
+            .Append(windowEvent.MemberName)
+            .AppendLine("]).Async -= value;");
         builder.AppendLine("    }");
         builder.AppendLine();
         builder.AppendLine("    [JSInvokable]");
@@ -214,13 +270,23 @@ public sealed class WindowEventsGenerator : IIncrementalGenerator
         if (windowEvent.ArgumentType2 is null)
         {
             builder.Append(windowEvent.ArgumentType1.ToDisplayString(typeFormat)).Append(" e");
-            builder.Append(") => ").Append(windowEvent.SlotName).AppendLine(".InvokeAsync(e);");
+            builder.Append(") => ((EventSlot<")
+                .Append(windowEvent.ArgumentType1.ToDisplayString(typeFormat))
+                .Append(">)_eventSlots[WindowEvent.")
+                .Append(windowEvent.MemberName)
+                .AppendLine("]).InvokeAsync(e);");
         }
         else
         {
             builder.Append(windowEvent.ArgumentType1.ToDisplayString(typeFormat)).Append(" arg1, ");
             builder.Append(windowEvent.ArgumentType2.ToDisplayString(typeFormat)).Append(" arg2");
-            builder.Append(") => ").Append(windowEvent.SlotName).AppendLine(".InvokeAsync(arg1, arg2);");
+            builder.Append(") => ((EventSlot<")
+                .Append(windowEvent.ArgumentType1.ToDisplayString(typeFormat))
+                .Append(", ")
+                .Append(windowEvent.ArgumentType2.ToDisplayString(typeFormat))
+                .Append(">)_eventSlots[WindowEvent.")
+                .Append(windowEvent.MemberName)
+                .AppendLine("]).InvokeAsync(arg1, arg2);");
         }
 
         builder.AppendLine();
@@ -269,14 +335,12 @@ public sealed class WindowEventsGenerator : IIncrementalGenerator
             ArgumentType1 = argumentType1;
             ArgumentType2 = argumentType2;
             InvocationSuffix = memberName.StartsWith("On", StringComparison.Ordinal) ? memberName.Substring(2) : memberName;
-            SlotName = "_" + char.ToLowerInvariant(InvocationSuffix[0]) + InvocationSuffix.Substring(1);
         }
 
         public string MemberName { get; }
 
         public string InvocationSuffix { get; }
 
-        public string SlotName { get; }
 
         public ITypeSymbol ArgumentType1 { get; }
 

--- a/src/BQuery/BqEvents.cs
+++ b/src/BQuery/BqEvents.cs
@@ -6,7 +6,12 @@ namespace BQuery;
 /// </summary>
 public partial class BqEvents
 {
+    private abstract class EventSlot
+    {
+    }
+
     private sealed class EventSlot<T>
+        : EventSlot
     {
         private Action<T>? _syncHandlers;
         private Func<T, Task>? _asyncHandlers;
@@ -49,6 +54,53 @@ public partial class BqEvents
         private static async Task InvokeAsyncHandler(Func<T, Task> handler, T args)
         {
             await handler(args);
+        }
+    }
+
+    private sealed class EventSlot<T1, T2>
+        : EventSlot
+    {
+        private Action<T1, T2>? _syncHandlers;
+        private Func<T1, T2, Task>? _asyncHandlers;
+
+        public event Action<T1, T2>? Sync
+        {
+            add => _syncHandlers += value;
+            remove => _syncHandlers -= value;
+        }
+
+        public event Func<T1, T2, Task>? Async
+        {
+            add => _asyncHandlers += value;
+            remove => _asyncHandlers -= value;
+        }
+
+        public async Task InvokeAsync(T1 arg1, T2 arg2)
+        {
+            if (_syncHandlers is not null)
+            {
+                foreach (var handler in _syncHandlers.GetInvocationList().Cast<Action<T1, T2>>())
+                {
+                    handler(arg1, arg2);
+                }
+            }
+
+            if (_asyncHandlers is not null)
+            {
+                List<Task>? pendingTasks = [];
+
+                foreach (var handler in _asyncHandlers.GetInvocationList().Cast<Func<T1, T2, Task>>())
+                {
+                    pendingTasks.Add(InvokeAsyncHandler(handler, arg1, arg2));
+                }
+
+                await Task.WhenAll(pendingTasks);
+            }
+        }
+
+        private static async Task InvokeAsyncHandler(Func<T1, T2, Task> handler, T1 arg1, T2 arg2)
+        {
+            await handler(arg1, arg2);
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Replace individual generated backing fields per window event with a single lookup to simplify generated code and reduce duplication. 
- Support both single-argument and two-argument window event handler signatures via a common dictionary-backed slot abstraction. 
- Make generated add/remove accessors and JS-invokable callbacks resolve slots at runtime to centralize slot storage and casting.

### Description

- Updated the source generator `WindowEventsGenerator` to emit a single `private readonly Dictionary<WindowEvent, EventSlot> _eventSlots` and populate it with `EventSlot<...>` instances for each discovered event instead of generating one field per event (`src/BQuery.SourceGenerators/WindowEventsGenerator.cs`).
- Changed generated event accessors and `[JSInvokable]` callback code to resolve the correct slot from `_eventSlots` and cast to the appropriate `EventSlot<...>` before adding/removing handlers or invoking (`src/BQuery.SourceGenerators/WindowEventsGenerator.cs`).
- Extended `BqEvents` to include a non-generic `EventSlot` base type and a new `EventSlot<T1, T2>` implementation alongside existing `EventSlot<T>` so dictionary values can represent both one-arg and two-arg event signatures (`src/BQuery/BqEvents.cs`).
- Removed the previous per-event `SlotName` generation and switched to dictionary-keyed slot lookup in generated output (`src/BQuery.SourceGenerators/WindowEventsGenerator.cs` and `src/BQuery/BqEvents.cs`).

### Testing

- Ran `git diff --check` as a quick validation of working-tree changes and it succeeded. 
- Ran repository inspections (`git status`, file diffs) to verify the intended changes were staged and present. 
- Attempted to run `dotnet build` to validate the generator in a real build but it could not be executed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afaa2c11a883219e9fbcf27e99caa9)